### PR TITLE
Updated FixedUpdate Movement and added the risizing to tiny with a timer

### DIFF
--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -1,21 +1,50 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
+using Unity.PlasticSCM.Editor.WebApi;
 using UnityEngine;
 
 public class PlayerMovement : MonoBehaviour
 {
-    [SerializeField] private float xMov, zMov;
-    [SerializeField] private float speed = 1.0f;
-    [SerializeField] private Rigidbody rb;
+    // Variables
+    private float xMov, zMov;
+    [SerializeField] private float speed = 5.0f;
+    private float delay = 3.0f;
+
+    private float nextTime;
+    private float currentTime;
+    // Components
+    private Rigidbody rb;
+    private Transform tr;
+    // Vectors
+    private Vector3 tinyScale = new(0.5f, 0.5f, 0.5f);
+    private Vector3 originalScale;
+    // Bools
+    [SerializeField] private bool isTiny = false;
+
 
     private void Start()
     {
         rb = GetComponent<Rigidbody>();
+        tr = GetComponent<Transform>();
+        originalScale = transform.localScale;
+        Debug.Log(transform.localScale);
     }
 
     private void Update()
     {
-        Movement();
+        currentTime += Time.deltaTime;
+
+        if (Input.GetKeyDown(KeyCode.G) && currentTime >= nextTime)
+        {
+            ChangingLocalScale();
+            nextTime = currentTime + delay;
+        }
+    }
+
+    private void FixedUpdate()
+    {
+        Movement();        
     }
 
     void Movement()
@@ -23,6 +52,19 @@ public class PlayerMovement : MonoBehaviour
         xMov = Input.GetAxisRaw("Horizontal");
         zMov = Input.GetAxisRaw("Vertical");
         rb.velocity = new Vector3(xMov * speed, rb.velocity.y, zMov * speed);
+    }
+    void ChangingLocalScale()
+    {
+        if(isTiny == false)
+        {
+            tr.localScale = tinyScale;
+            isTiny = true;
+        }
+        else
+        {
+            tr.localScale = originalScale;
+            isTiny = false;
+        }
     }
 }
     


### PR DESCRIPTION


# Pull Request

## Description
[-Movement moved to FixedUpdate
-Now Resizing
-Added a timer so we can't keep pressing the G key to resize all the time, now it's 3 seconds delay to be able to resize again. (I'd like to have it smoothier)..]


## Screenshots/GIFs (if applicable)
![image](https://github.com/kelly1801/Tiny-world-jam/assets/117759492/b094ed56-ca57-490d-b080-28d7ac5ac20f)


## Checklist
Please make sure that your PR fulfills the following criteria:

- [ x] I have reviewed my code to ensure it follows the project's coding standards.
- [x ] I have tested my changes thoroughly to ensure they work as expected.
- [x ] I have communicated any major architectural changes or decisions in this PR.
- [x ] I have updated relevant comments and commit messages for clarity.
- [x ] I have resolved all merge conflicts.

## Additional Notes (if any)
[I'd like if there's time to make the transition to tiny with a for decreasing every frame the .LocalScale [in such case, move it to fixedupdate then.]

## Reviewer Checklist (for Reviewers)
- [x] The code adheres to project coding standards.
- [x] The changes solve the described issue or implement the feature correctly.
- [x] The code is properly formatted and well-commented.
- [x] Any necessary code or design changes have been discussed and approved.
- [x] The PR can be merged without causing issues or conflicts.

## Definition of Done (for Maintainers)
- [x] Code has been reviewed and approved by at least two reviewer.
- [x] All discussions and comments have been addressed.
- [x] The PR is up to date with the latest main/develop branch.
- [x] The PR can be merged without issues.


## Labels
[future & enhancement]
